### PR TITLE
fix: don't stop rendering messages on streamlit reload

### DIFF
--- a/src/rapport/chatgateway.py
+++ b/src/rapport/chatgateway.py
@@ -362,18 +362,18 @@ class OpenAIAdaptor(ChatAdaptor):
 
         remaining = [m for m in messages if not isinstance(m, SystemMessage)]
         for m in remaining:
-            match m:
-                case UserMessage():
+            match m.type:
+                case "UserMessage":
                     x = ChatCompletionUserMessageParam(
                         role="user", content=m.message
                     )
                     result.append(x)
-                case AssistantMessage():
+                case "AssistantMessage":
                     x = ChatCompletionAssistantMessageParam(
                         role="assistant", content=m.message
                     )
                     result.append(x)
-                case IncludedFile():
+                case "IncludedFile":
                     # This format seems to work well for models without
                     # a specific document type in their API.
                     prompt = f"""
@@ -386,7 +386,7 @@ class OpenAIAdaptor(ChatAdaptor):
                         role="user", content=prompt
                     )
                     result.append(x)
-                case IncludedImage():
+                case "IncludedImage":
                     result.append(self._prepare_imageblockparam(m.path))
 
         return result
@@ -451,24 +451,24 @@ class AnthropicAdaptor(ChatAdaptor):
 
         for m in messages:
             mp = None
-            match m:
-                case UserMessage():
+            match m.type:
+                case "UserMessage":
                     mp = MessageParam(
                         role="user",
                         content=m.message,
                     )
-                case AssistantMessage():
+                case "AssistantMessage":
                     mp = MessageParam(
                         role="assistant",
                         content=m.message,
                     )
-                case IncludedFile():
+                case "IncludedFile":
                     p = self._prepare_documentblockparam(m.data)
                     mp = MessageParam(
                         role="user",
                         content=[p],
                     )
-                case IncludedImage():
+                case "IncludedImage":
                     p = self._prepare_imageblockparam(m.path)
                     mp = MessageParam(
                         role="user",

--- a/src/rapport/view_chat.py
+++ b/src/rapport/view_chat.py
@@ -469,26 +469,31 @@ def render_sidebar():
 def render_chat_messages():
     # Display chat messages from history on app rerun
     for message in _s.chat.messages:
-        match message:
-            case SystemMessage(message=message):
+        # Use the type discriminator field to determine the message type
+        match message.type:
+            case "SystemMessage":
                 with st.expander("View system prompt"):
-                    st.markdown(message)
-            case IncludedFile(name=name, ext=ext, data=data, role=role):
-                with st.chat_message(role, avatar=":material/upload_file:"):
-                    st.markdown(f"Included `{name}` in chat.")
+                    st.markdown(message.message)
+            case "IncludedFile":
+                with st.chat_message(
+                    message.role, avatar=":material/upload_file:"
+                ):
+                    st.markdown(f"Included `{message.name}` in chat.")
                     with st.expander("View file content"):
-                        st.markdown(f"```{ext}\n{data}\n```")
-            case IncludedImage(name=name, path=path, role=role):
-                with st.chat_message(role, avatar=":material/image:"):
-                    st.markdown(f"Included image `{name}` in chat.")
+                        st.markdown(f"```{message.ext}\n{message.data}\n```")
+            case "IncludedImage":
+                with st.chat_message(
+                    message.role, avatar=":material/image:"
+                ):
+                    st.markdown(f"Included image `{message.name}` in chat.")
                     if _s.chat_gateway.supports_images(_s.model):
                         # make the image a bit smaller
                         a, _ = st.columns([1, 2])
                         with a:
-                            st.image(str(path))
+                            st.image(str(message.path))
                     else:
                         st.warning("Change model to use images.")
-            case AssistantMessage() | UserMessage():
+            case "AssistantMessage" | "UserMessage":
                 with st.chat_message(message.role):
                     st.markdown(message.message)
 


### PR DESCRIPTION
Fixes: https://github.com/mikerhodes/rapport/issues/27

When changing code, often messages will stop rendering in the chat
history and will not be processed correctly when creating messages
to send to the AI model. I think this is because somehow the classes
loaded by the chat history become "out of sync" with the types used
in the match statement.

Specifically, I found that directly matching on the type using `case
SystemMessage()` failed after streamlit reloads. I'm not exactly sure
why, but it meant that both chat history rendering failed, and preparing
messages to send to the model.

This made updating Rapport more of a chore because you'd have to
restart the app (usually after a moment of staring at a blank screen)
in order to test new changes. Not the end of the world but repeatedly
frustrating, which isn't great.

I also tried out using isinstance(o, SystemMessage) but that had the
same problem.
