### PR TITLE
Add tool calling from MCP servers

### DIFF
--- a/mcphttp.py
+++ b/mcphttp.py
@@ -1,0 +1,61 @@
+# /// script
+# dependencies = [
+#   "fastmcp",
+# ]
+# ///
+
+# A simple MCP server to demonstrate Rapport's functionality.
+# It can be added to Rapport using this configuration:
+# {
+# "mcpdemo": {
+#     "url": "http://127.0.0.1:9000/mcp/",
+#     "allowed_tools": [
+#         "add",
+#         "mul",
+#     ]
+# },
+# }
+# Run the script using `uv run mcpdemo.py`.
+
+from fastmcp import FastMCP
+
+# Create MCP server instance
+server = FastMCP(name="addserver")
+
+
+# Define the "add" function handler
+@server.tool()
+async def add(a: int, b: int) -> int:
+    """
+    Add two numbers and return the result.
+
+    Parameters:
+    a (int): First number
+    b (int): Second number
+
+    Returns:
+    int: Sum of the two numbers
+    """
+    return a + b
+
+
+@server.tool()
+async def mul(a: int, b: int) -> int:
+    """
+    Multiply two numbers and return the result.
+
+    Parameters:
+    a (int): First number
+    b (int): Second number
+
+    Returns:
+    int: Result of multiplying the two numbers
+    """
+    return a * b
+
+
+# Run the server on default host and port (localhost:8000)
+if __name__ == "__main__":
+    print("Starting MCP server...")
+    print("Server running at http://localhost:9000")
+    server.run(transport="streamable-http", host="127.0.0.1", port=9000)

--- a/mcpstdio.py
+++ b/mcpstdio.py
@@ -1,0 +1,83 @@
+# /// script
+# dependencies = [
+#   "fastmcp",
+#   "httpx",
+#   "markdownify",
+#   "beautifulsoup4"
+# ]
+# ///
+
+# A simple MCP server to demonstrate Rapport's functionality.
+# It can be added to Rapport using this configuration:
+# {
+# "mcpdemo": {
+#     "command": "uv",
+#     "args": ["run", "mcpstdio.py"]
+#     "allowed_tools": [
+#         "download_url"
+#     ]
+# },
+# }
+# Rapport will start the server as needed.
+
+from fastmcp import FastMCP
+import httpx
+from markdownify import MarkdownConverter
+from bs4 import BeautifulSoup
+
+# Create MCP server instance
+server = FastMCP(name="stdiomcp")
+
+
+@server.tool()
+def download_url(url: str) -> str:
+    """
+    Download a webpage and convert its content to markdown.
+
+    Args:
+        url: The URL to download
+
+    Returns:
+        Markdown content as a string
+    """
+    # Fetch the webpage content
+    response = httpx.get(url)
+    response.raise_for_status()  # Raise an error for bad responses
+
+    # Super-basic cleanup before passing to markdownify
+    simple_unsafe_tags = [
+        # Script and style tags (potential XSS risks)
+        "script",
+        "style",
+        # Embedded content that could be problematic
+        "iframe",
+        "object",
+        "embed",
+        "applet",
+        # Forms and input elements
+        "form",
+        "input",
+        "button",
+        "select",
+        "textarea",
+        # Potentially dangerous event handlers
+        "meta",  # could contain refresh or redirect
+    ]
+    soup = BeautifulSoup(response.text, "html.parser")
+    for tag in simple_unsafe_tags:
+        for element in soup.find_all(tag):
+            element.decompose()
+
+    # Convert HTML to markdown
+
+    markdown_content = MarkdownConverter(heading_style="ATX").convert_soup(
+        soup
+    )
+
+    return markdown_content
+
+
+# Run the server on default host and port (localhost:8000)
+if __name__ == "__main__":
+    print("Starting MCP server...")
+    server.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,14 @@
 [project]
 name = "rapport"
-version = "0.11.0"
+version = "0.12.0"
 description = "A locally hosted chatbot supporting several providers"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "anthropic>=0.46.0",
+    "fastmcp>=2.3.4",
     "ibm-watsonx-ai>=1.2.9",
+    "more-itertools>=10.7.0",
     "ollama>=0.4.7",
     "openai>=1.74.0",
     "pydantic>=2.6.0",

--- a/src/rapport/chatgateway.py
+++ b/src/rapport/chatgateway.py
@@ -6,18 +6,18 @@ from pathlib import Path
 from typing import (
     Dict,
     Generator,
+    Iterable,
     List,
     Optional,
     Protocol,
     Tuple,
     cast,
-    Iterable,
 )
 
 import ibm_watsonx_ai as wai
 import ibm_watsonx_ai.foundation_models as waifm
-import openai
 import ollama
+import openai
 from anthropic import Anthropic
 from anthropic.types import (
     Base64ImageSourceParam,
@@ -27,6 +27,8 @@ from anthropic.types import (
     MessageParam,
     PlainTextSourceParam,
     TextBlockParam,
+    ToolResultBlockParam,
+    ToolUseBlockParam,
 )
 from ibm_watsonx_ai.wml_client_error import WMLClientError
 from openai.types.chat import (
@@ -43,8 +45,11 @@ from rapport.chatmodel import (
     IncludedImage,
     MessageList,
     SystemMessage,
+    ToolCallMessage,
+    ToolResultMessage,
     UserMessage,
 )
+from rapport.tools import Tool
 
 logger = logging.getLogger(__name__)
 
@@ -67,6 +72,7 @@ class MessageChunk:
     output_tokens: Optional[int]
     content: str
     finish_reason: Optional[FinishReason]
+    tool_call: Optional[ToolCallMessage]
 
 
 class ChatAdaptor(Protocol):
@@ -80,6 +86,7 @@ class ChatAdaptor(Protocol):
         self,
         model: str,
         messages: MessageList,
+        tools: List[Tool],
     ) -> Generator[MessageChunk, None, None]: ...
 
 
@@ -151,11 +158,13 @@ class ChatGateway:
         self,
         model: str,
         messages: MessageList,
+        tools: List[Tool],
     ) -> Generator[MessageChunk, None, None]:
         c = self.model_to_client[model]
         response = c.chat(
             model=model,
             messages=messages,
+            tools=tools,
         )
         for chunk in response:
             yield chunk
@@ -232,6 +241,7 @@ class OllamaAdaptor(ChatAdaptor):
         self,
         model: str,
         messages: MessageList,
+        tools: List[Tool],
     ) -> Generator[MessageChunk, None, None]:
         messages_content = _prepare_messages_for_model(messages)
         m = self._show(model)
@@ -298,6 +308,7 @@ class OpenAIAdaptor(ChatAdaptor):
         self,
         model: str,
         messages: MessageList,
+        tools: List[Tool],
     ) -> Generator[MessageChunk, None, None]:
         # cast until we make an openai specific message prep function
         messages_content = self._prepare_messages_for_model(messages)
@@ -455,12 +466,22 @@ class AnthropicAdaptor(ChatAdaptor):
                 case "UserMessage":
                     mp = MessageParam(
                         role="user",
-                        content=m.message,
+                        content=[
+                            TextBlockParam(
+                                type="text",
+                                text=m.message,
+                            )
+                        ],
                     )
-                case "AssistantMessage":
+                case "AssistantMessage" if m.message:
                     mp = MessageParam(
                         role="assistant",
-                        content=m.message,
+                        content=[
+                            TextBlockParam(
+                                type="text",
+                                text=m.message,
+                            )
+                        ],
                     )
                 case "IncludedFile":
                     p = self._prepare_documentblockparam(m.data)
@@ -474,6 +495,29 @@ class AnthropicAdaptor(ChatAdaptor):
                         role="user",
                         content=[p],
                     )
+                case "ToolCallMessage":
+                    mp = MessageParam(
+                        role="assistant",
+                        content=[
+                            ToolUseBlockParam(
+                                type="tool_use",
+                                id=m.id,
+                                input=m.parameters,
+                                name=m.name,
+                            )
+                        ],
+                    )
+                case "ToolResultMessage":
+                    mp = MessageParam(
+                        role="user",
+                        content=[
+                            ToolResultBlockParam(
+                                tool_use_id=m.id,
+                                type="tool_result",
+                                content=m.result,
+                            )
+                        ],
+                    )
                 case _:
                     pass
             if mp:
@@ -481,20 +525,12 @@ class AnthropicAdaptor(ChatAdaptor):
 
         # If last message is user, apply prompt caching
         match output[-1]:
-            case {"role": "user", "content": c}:
+            case {"role": "user", "content": [c]}:
                 print("applying prompt caching")
-                output[-1] = MessageParam(
-                    role="user",
-                    content=[
-                        TextBlockParam(
-                            type="text",
-                            text=c,
-                            cache_control=CacheControlEphemeralParam(
-                                type="ephemeral"
-                            ),
-                        )
-                    ],
+                c["cache_control"] = CacheControlEphemeralParam(
+                    type="ephemeral"
                 )
+                output[-1] = MessageParam(role="user", content=[c])
 
         return (system_prompt, output)
 
@@ -560,46 +596,134 @@ class AnthropicAdaptor(ChatAdaptor):
         self,
         model: str,
         messages: MessageList,
+        tools: List[Tool],
     ) -> Generator[MessageChunk, None, None]:
         system_prompt, anth_messages = self._prepare_messages_for_model(
             messages
         )
 
-        chunk_stream = self.c.messages.create(
-            max_tokens=8192,
-            messages=anth_messages,
-            model=model,
-            stream=True,
-            system=system_prompt,
-        )
-        input_tokens = 0
+        anth_tools = [x.render_anthropic() for x in tools]
+
+        chunk_stream = None
+        try:
+            chunk_stream = self.c.messages.create(
+                max_tokens=8192,
+                messages=anth_messages,
+                model=model,
+                stream=True,
+                system=system_prompt,
+                tools=anth_tools,
+            )
+            input_tokens = 0
+        except Exception as ex:
+            print(messages)
+            print("=" * 20)
+            print(anth_messages)
+            print(ex)
+
+        if chunk_stream is None:
+            return
+
+        from enum import Enum
+        import json
+
+        class StreamState(Enum):
+            START = 1
+            TEXT = 2
+            TOOL = 3
+
+        state = StreamState.START
+        tool_call_id = ""
+        tool_call_name = ""
+        tool_call_input = ""
+
         for event in chunk_stream:
             # logger.info(event.type)
             content = ""
             finish_reason = None
             output_tokens = None
 
-            match event.type:
-                case "message_start":
-                    input_tokens = event.message.usage.input_tokens
-                case "content_block_delta" if (
-                    event.delta.type == "text_delta"
-                ):
-                    content = event.delta.text
-                case "message_delta":
-                    output_tokens = event.usage.output_tokens
-                    match event.delta.stop_reason:
-                        case "max_tokens":
-                            finish_reason = FinishReason.Length
+            match state:
+                case StreamState.START:
+                    match event.type:
+                        case "message_start":
+                            input_tokens = event.message.usage.input_tokens
+                        case "content_block_start" if (
+                            event.content_block.type == "text"
+                        ):
+                            # new text content
+                            state = StreamState.TEXT
+                        case "content_block_start" if (
+                            event.content_block.type == "tool_use"
+                        ):
+                            # new tool call
+                            state = StreamState.TOOL
+                            tool_call_id = event.content_block.id
+                            tool_call_name = event.content_block.name
+                            tool_call_input = ""
+                        case "message_delta":
+                            output_tokens = event.usage.output_tokens
+                            match event.delta.stop_reason:
+                                case "max_tokens":
+                                    finish_reason = FinishReason.Length
+                                case _:
+                                    finish_reason = FinishReason.Stop
+                        case "message_stop":
+                            pass  # should be the last message
                         case _:
-                            finish_reason = FinishReason.Stop
-
-            yield MessageChunk(
-                content=content,
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                finish_reason=finish_reason,
-            )
+                            print(event)
+                    yield MessageChunk(
+                        content="",
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                        finish_reason=finish_reason,
+                        tool_call=None,
+                    )
+                case StreamState.TEXT:
+                    match event.type:
+                        case "content_block_delta" if (
+                            event.delta.type == "text_delta"
+                        ):
+                            content = event.delta.text
+                            yield MessageChunk(
+                                content=content,
+                                input_tokens=None,
+                                output_tokens=None,
+                                finish_reason=None,
+                                tool_call=None,
+                            )
+                        case "content_block_stop":
+                            state = StreamState.START
+                        case _:
+                            print(event)
+                case StreamState.TOOL:
+                    match event.type:
+                        case "content_block_delta" if (
+                            event.delta.type == "input_json_delta"
+                        ):
+                            tool_call_input += event.delta.partial_json
+                        case "content_block_stop":
+                            print(
+                                "tool_call:",
+                                tool_call_id,
+                                tool_call_name,
+                                tool_call_input,
+                            )
+                            yield MessageChunk(
+                                content="",
+                                input_tokens=None,
+                                output_tokens=None,
+                                finish_reason=None,
+                                tool_call=ToolCallMessage(
+                                    id=tool_call_id,
+                                    name=tool_call_name,
+                                    parameters=json.loads(tool_call_input),
+                                ),
+                            )
+                            # yield tool use
+                            state = StreamState.START
+                        case _:
+                            print(event)
 
 
 class WatsonxAdaptor(ChatAdaptor):
@@ -678,6 +802,7 @@ class WatsonxAdaptor(ChatAdaptor):
         self,
         model: str,
         messages: MessageList,
+        tools: List[Tool],
     ) -> Generator[MessageChunk, None, None]:
         messages_content = _prepare_messages_for_model(messages)
         fmodel = self._model_inference(model)

--- a/src/rapport/chatmodel.py
+++ b/src/rapport/chatmodel.py
@@ -7,8 +7,7 @@ Trying to keep this indepdent from streamlit.
 from datetime import datetime
 from importlib import resources
 from pathlib import Path
-from typing import Annotated, List, Literal, Optional, Union
-
+from typing import Union, List, Optional, Literal, Annotated, Dict, Any
 from pydantic import BaseModel, Field
 
 from rapport.appconfig import ConfigStore
@@ -52,6 +51,22 @@ class IncludedImage(BaseModel):
     type: Literal["IncludedImage"] = "IncludedImage"
 
 
+class ToolCallMessage(BaseModel):
+    id: str
+    name: str
+    parameters: Dict[str, Any]
+    role: Literal["assistant"] = "assistant"
+    type: Literal["ToolCallMessage"] = "ToolCallMessage"
+
+
+class ToolResultMessage(BaseModel):
+    id: str
+    name: str
+    result: str
+    role: Literal["tool"] = "tool"
+    type: Literal["ToolResultMessage"] = "ToolResultMessage"
+
+
 # This tells pydantic that the `type` field is used to figure
 # out which of the message types to parse the JSON into.
 Message = Annotated[
@@ -61,6 +76,8 @@ Message = Annotated[
         AssistantMessage,
         IncludedFile,
         IncludedImage,
+        ToolCallMessage,
+        ToolResultMessage,
     ],
     Field(discriminator="type"),
 ]

--- a/src/rapport/entrypoint.py
+++ b/src/rapport/entrypoint.py
@@ -3,12 +3,14 @@ from pathlib import Path
 
 import streamlit as st
 
+from rapport import tools
 from rapport.chathistory import ChatHistoryManager
 from rapport.chatgateway import ChatGateway
 from rapport.chatmodel import PAGE_CHAT, PAGE_CONFIG, PAGE_HELP, PAGE_HISTORY
 from rapport.appconfig import ConfigStore
 
 logging.basicConfig(level=logging.INFO)
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 st.set_page_config(
     page_title="Rapport",
@@ -77,5 +79,6 @@ if "history_manager" not in st.session_state:
 if "chat_gateway" not in st.session_state:
     st.session_state["chat_gateway"] = gateway()
 
+tools.registry.initialise_tools(st.session_state["config_store"])
 
 pg.run()

--- a/src/rapport/tools.py
+++ b/src/rapport/tools.py
@@ -1,0 +1,197 @@
+import asyncio
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from fastmcp.client import StdioTransport
+import httpx
+from anthropic.types import ToolUnionParam
+from fastmcp import Client
+
+from rapport.appconfig import ConfigStore, StdioMCPServer, URLMCPServer
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+
+@dataclass
+class Tool:
+    name: str
+    description: str
+    function_name: str
+    parameters: Dict[str, Any]  # JSON schema for parameters
+    server: URLMCPServer | StdioMCPServer
+    enabled: bool = True
+
+    def render_openai(self) -> Dict[str, Any]:
+        """Return the commonly used openai tool schema for this tool"""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "parameters": self.parameters,
+        }
+
+    def render_anthropic(self) -> ToolUnionParam:
+        """Return the anthropic-specific tool schema for this tool"""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self.parameters,
+        }
+
+
+class ToolRegistry:
+    def __init__(self):
+        self._client_cache: Dict[str, Any] = {}
+        self._client_cache_lock = asyncio.Lock()
+        self.tools: Dict[str, Tool] = {}  # Tool.name : Tool
+        self._tools_lock = threading.Lock()
+        self._initialised = False
+
+    # To create a thing where instead each Client is connected
+    # and running, we could use an approach where we have
+    # an infinite loop running on a async function for each
+    # client. It pulls a tuple of (data, response_queue) from
+    # its input queue, and replies on response_queue.
+    # We'd instead store the input queues in something like client_cache
+    # Shutting down, we'd send None on the queue perhaps.
+    # See Claude chat.
+
+    async def _get_client(self, server: URLMCPServer | StdioMCPServer):
+        async with self._client_cache_lock:
+            if server.id not in self._client_cache:
+                logger.debug("Creating Client for %s", server)
+                match server:
+                    case URLMCPServer():
+                        self._client_cache[server.id] = Client(server.url)
+                    case StdioMCPServer():
+                        self._client_cache[server.id] = Client(
+                            StdioTransport(server.command, server.args)
+                        )
+            client = self._client_cache[server.id]
+        return client
+
+    async def _list_tools(self, server: URLMCPServer | StdioMCPServer):
+        client = await self._get_client(server)
+
+        # Connection is established here
+        async with client:
+            logger.debug(f"Client connected: {client.is_connected()}")
+
+            # Make MCP calls within the context
+            tools = await client.list_tools()
+
+        return tools
+
+    async def _run_tool(self, tool: Tool, params: Dict[str, Any]):
+        client = await self._get_client(tool.server)
+        result = None
+
+        async with client:
+            logger.debug(f"Client connected: {client.is_connected()}")
+
+            # Make MCP calls within the context
+            tools = await client.list_tools()
+
+            if any(t.name == tool.name for t in tools):
+                result = await client.call_tool(tool.name, params)
+
+        if result is not None:
+            return "\n".join([x.text for x in result if x.type == "text"])
+
+    def _get_available_tools(
+        self, s: URLMCPServer | StdioMCPServer
+    ) -> List[Tool]:
+        """Return all available tools"""
+        try:
+            tools = asyncio.run(self._list_tools(s))
+        except httpx.HTTPError as ex:
+            logger.warning("MCP server %s unreachable: %s", s, ex)
+            tools = []
+
+        return [
+            Tool(
+                name=x.name,
+                description=x.description or "",
+                function_name=x.name,
+                parameters=x.inputSchema,
+                server=s,
+            )
+            for x in tools
+        ]
+
+    def _iterate_enabled_tools(self, config: ConfigStore):
+        mcp_servers = config.load_config().mcp_servers
+        seen_tools = set()  # no dup tool names
+        # Find URL where tool is available and allowed
+        for n, s in mcp_servers.items():
+            logger.debug("Processing MCP server: %s", s)
+
+            # Don't enable any tools if there are duplicate names
+            available_tools = self._get_available_tools(s)
+            for n in [x.name for x in available_tools]:
+                if n in seen_tools:
+                    logger.error(
+                        "Duplicate tool name, disabling tools: %s", n
+                    )
+                    raise ValueError(
+                        "Duplicate tool name, disabling tools: " + n
+                    )
+                seen_tools.add(n)
+
+            allowed_tools = [x.strip() for x in s.allowed_tools]
+            if allowed_tools and available_tools:
+                for x in [
+                    x for x in available_tools if x.name in allowed_tools
+                ]:
+                    yield x
+
+    def initialise_tools(self, config: ConfigStore):
+        """
+        Initialise availabe tools from config.
+
+        Safe to call repeatedly. Once called, subsequent calls
+        will be noops.
+        """
+        if self._initialised:
+            return
+        new_tools: Dict[str, Tool] = {}
+        for tool in self._iterate_enabled_tools(config=config):
+            new_tools[tool.name] = tool
+            logger.debug("added tool: %s: %s", tool.name, tool.server)
+        with self._tools_lock:
+            self.tools = new_tools
+        self._initialised = True
+
+    def get_enabled_tools(self) -> List[Tool]:
+        """Return only enabled tools based on their names"""
+        if not self._initialised:
+            raise RuntimeError("Tools not initialised")
+
+        ts: List[Tool] = []
+        with self._tools_lock:
+            for tool in self.tools.values():
+                ts.append(tool)
+        return ts
+
+    def _get_tool(self, name: str) -> Optional[Tool]:
+        with self._tools_lock:
+            t = self.tools.get(name, None)
+            return t
+
+    def execute_tool(self, tool_name: str, params: Dict[str, Any]) -> str:
+        """Execute a tool with the given parameters"""
+        if not self._initialised:
+            raise RuntimeError("Tools not initialised")
+
+        tool = self._get_tool(tool_name)
+        if tool is None:
+            raise ValueError(f"Unknown tool: {tool_name}")
+
+        # validate correct params?
+        result = asyncio.run(self._run_tool(tool, params))
+        return result or ""
+
+
+registry = ToolRegistry()

--- a/src/rapport/view_config.py
+++ b/src/rapport/view_config.py
@@ -1,63 +1,116 @@
 import streamlit as st
-from pathlib import Path
+from pydantic import TypeAdapter, ValidationError
 
-from rapport.appconfig import Config, ConfigStore
+from rapport import tools
+from rapport.appconfig import Config, ConfigStore, MCPServerList
 
 st.title("Settings")
 
 # Get config store from session state
-config_store = st.session_state["config_store"]
+config_store: ConfigStore = st.session_state["config_store"]
 config = config_store.load_config()
 
 # Create form for editing settings
 with st.form("settings_form"):
-    st.subheader("AI Model Configuration")
+    tab1, tab2, tab3 = st.tabs(["General", "Custom prompt", "MCP Servers"])
+    with tab1:
+        st.subheader("AI Model Configuration")
 
-    # Display last used model as read-only information
-    if config.last_used_model:
-        st.markdown(f"Last used model: `{config.last_used_model}`")
+        # Display last used model as read-only information
+        if config.last_used_model:
+            st.markdown(f"Last used model: `{config.last_used_model}`")
 
-    preferred_model = st.text_input(
-        "Preferred model (leave blank to use last used)",
-        value=config.preferred_model or "",
-        placeholder="Enter your preferred AI model",
-    )
+        preferred_model = st.text_input(
+            "Preferred model (leave blank to use last used)",
+            value=config.preferred_model or "",
+            placeholder="Enter your preferred AI model",
+        )
 
-    custom_system_prompt = st.text_area(
-        "Details you want the model to know about you:",
-        value=config.custom_system_prompt or "",
-        placeholder="Enter things about you (eg, 'I like Python') or customisations to the model's behaviour (eg, 'be sarcastic a lot')",
-        height=150,
-        help="Feel free to phrase this using 'I', such as 'I like cats'",
-    )
+        st.subheader("Obsidian integration")
 
-    st.subheader("Obsidian integration")
+        obsidian_directory = st.text_input(
+            "Obsidian directory path (Save to Obsidian will use this path, likely it should be a subdirectory inside your vault)",
+            value=config.obsidian_directory or "",
+            placeholder="Enter your Obsidian vault directory path",
+        )
 
-    obsidian_directory = st.text_input(
-        "Obsidian directory path (Save to Obsidian will use this path, likely it should be a subdirectory inside your vault)",
-        value=config.obsidian_directory or "",
-        placeholder="Enter your Obsidian vault directory path",
-    )
+    with tab2:
+        st.subheader("Custom system prompt")
+        custom_system_prompt = st.text_area(
+            "Details you want the model to know about you:",
+            value=config.custom_system_prompt or "",
+            placeholder="Enter things about you (eg, 'I like Python') or customisations to the model's behaviour (eg, 'be sarcastic a lot')",
+            height=300,
+            help="Feel free to phrase this using 'I', such as 'I like cats'",
+        )
+
+    with tab3:
+        st.subheader("MCP Servers")
+        with st.expander("JSON configuration examples"):
+            st.markdown("""
+            Rapport only supports tools that support a
+            HTTP interface. It uses JSON configuration
+            to add each MCP server to Rapport. You must
+            explicitly list the allowed tools.
+
+            These configuration examples are for the
+            mcphttp.py and mcpstdio.py examples that
+            ship with Rapport.
+            """)
+            st.caption("Hover to copy to clipboard")
+            st.json("""{
+                "addmcp": {
+                    "url": "http://127.0.0.1:9000/mcp/",
+                    "allowed_tools": ["add","mul"]
+                },
+                "mcpstdio": {
+                    "command": "uv",
+                    "args": ["run","mcpstdio.py"],
+                    "allowed_tools": ["download_url"]
+                }
+            }""")
+        with st.expander("Currently loaded tools"):
+            for t in tools.registry.get_enabled_tools():
+                st.markdown(f"`{t.name}` from `{t.server}`")
+        ta = TypeAdapter(MCPServerList)
+        mcp_str = ta.dump_json(config.mcp_servers, indent=4).decode("utf-8")
+        mcp_servers = st.text_area(
+            "MCP JSON configuration",
+            label_visibility="collapsed",
+            value=mcp_str,
+            placeholder="http://localhost:9000 add,multiple,divide",
+            height=300,
+        )
 
     # Submit button
     submitted = st.form_submit_button("Save Settings")
 
     if submitted:
-        # Update config with new values
-        new_config = Config(
-            preferred_model=preferred_model if preferred_model else None,
-            obsidian_directory=obsidian_directory
-            if obsidian_directory
-            else None,
-            last_used_model=config.last_used_model,
-            custom_system_prompt=custom_system_prompt
-            if custom_system_prompt
-            else None,
-        )
+        mcp = {}
+        try:
+            ta = TypeAdapter(MCPServerList)
+            mcp = ta.validate_json(mcp_servers if mcp_servers else "{}")
+        except ValidationError as ex:
+            # logger.error("Error saving configuration: %s", ex)
+            st.error(f"Error validating MCP servers:\n\n{str(ex)}")
 
-        # Save to disk
-        config_store.save_config(new_config)
-        st.success("Settings saved successfully!")
+        # Update config with new values
+        if mcp:
+            new_config = Config(
+                preferred_model=preferred_model if preferred_model else None,
+                obsidian_directory=obsidian_directory
+                if obsidian_directory
+                else None,
+                last_used_model=config.last_used_model,
+                custom_system_prompt=custom_system_prompt
+                if custom_system_prompt
+                else None,
+                mcp_servers=mcp,
+            )
+
+            # Save to disk
+            config_store.save_config(new_config)
+            st.success("Settings saved successfully!")
 
 # Add some helpful information
 with st.expander("Help"):

--- a/uv.lock
+++ b/uv.lock
@@ -160,6 +160,37 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674 },
+]
+
+[[package]]
+name = "fastmcp"
+version = "2.3.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typer" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/75/d9/cc3eb61c59fec834a9492ea21df134381b4be76c35faa18cd2b0249278b8/fastmcp-2.3.4.tar.gz", hash = "sha256:f3fe004b8735b365a65ec2547eeb47db8352d5613697254854bc7c9c3c360eea", size = 998315 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/e6/310d1fe6708b7338e1f48915a13d8bf00fd0599acdc7bf98da4fd20fcb66/fastmcp-2.3.4-py3-none-any.whl", hash = "sha256:12a45f72dd95aeaa1a6a56281fff96ca46929def3ccd9f9eb125cb97b722fbab", size = 96393 },
+]
+
+[[package]]
 name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -218,6 +249,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819 },
 ]
 
 [[package]]
@@ -377,6 +417,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -412,6 +464,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098 },
     { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208 },
     { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739 },
+]
+
+[[package]]
+name = "mcp"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "python-multipart" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/8d/0f4468582e9e97b0a24604b585c651dfd2144300ecffd1c06a680f5c8861/mcp-1.9.0.tar.gz", hash = "sha256:905d8d208baf7e3e71d70c82803b89112e321581bcd2530f9de0fe4103d28749", size = 281432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/d5/22e36c95c83c80eb47c83f231095419cf57cf5cca5416f1c960032074c78/mcp-1.9.0-py3-none-any.whl", hash = "sha256:9dfb89c8c56f742da10a5910a1f64b0d2ac2c3ed2bd572ddb1cfab7f35957178", size = 125082 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/a0/834b0cebabbfc7e311f30b46c8188790a37f89fc8d756660346fe5abfd09/more_itertools-10.7.0.tar.gz", hash = "sha256:9fddd5403be01a94b204faadcff459ec3568cf110265d3c54323e1e866ad29d3", size = 127671 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/9f/7ba6f94fc1e9ac3d2b853fdff3035fb2fa5afbed898c4a72b8a020610594/more_itertools-10.7.0-py3-none-any.whl", hash = "sha256:d43980384673cb07d2f7d2d918c616b30c659c089ee23953f601d6609c67510e", size = 65278 },
 ]
 
 [[package]]
@@ -491,6 +581,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c0/ea2e9a78bf88404b97e7b708f0823b4699ab2ee3f5564425b8531a890a43/openai-1.77.0.tar.gz", hash = "sha256:897969f927f0068b8091b4b041d1f8175bcf124f7ea31bab418bf720971223bc", size = 435778 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/90/58/37ae3ca75936b824a0a5ca30491c968192007857319d6836764b548b9d9b/openai-1.77.0-py3-none-any.whl", hash = "sha256:07706e91eb71631234996989a8ea991d5ee56f0744ef694c961e0824d4f39218", size = 662031 },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381 },
 ]
 
 [[package]]
@@ -684,6 +786,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/1d/42628a2c33e93f8e9acbde0d5d735fa0850f3e6a2f8cb1eb6c40b9a732ac/pydantic_settings-2.9.1.tar.gz", hash = "sha256:c509bf79d27563add44e8446233359004ed85066cd096d8b510f715e6ef5d268", size = 163234 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/5f/d6d641b490fd3ec2c4c13b4244d68deea3a1b970a97be64f34fb5504ff72/pydantic_settings-2.9.1-py3-none-any.whl", hash = "sha256:59b4f431b1defb26fe620c71a7d3968a710d719f5f4cdbbdb7926edeb770f6ef", size = 44356 },
+]
+
+[[package]]
 name = "pydeck"
 version = "0.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -694,6 +810,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/ca/40e14e196864a0f61a92abb14d09b3d3da98f94ccb03b49cf51688140dab/pydeck-0.9.1.tar.gz", hash = "sha256:f74475ae637951d63f2ee58326757f8d4f9cd9f2a457cf42950715003e2cb605", size = 3832240 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/4c/b888e6cf58bd9db9c93f40d1c6be8283ff49d88919231afe93a6bcf61626/pydeck-0.9.1-py2.py3-none-any.whl", hash = "sha256:b3f75ba0d273fc917094fa61224f3f6076ca8752b93d46faf3bcfd9f9d59b038", size = 6900403 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
 ]
 
 [[package]]
@@ -709,6 +834,24 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256 },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546 },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -719,11 +862,13 @@ wheels = [
 
 [[package]]
 name = "rapport"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "fastmcp" },
     { name = "ibm-watsonx-ai" },
+    { name = "more-itertools" },
     { name = "ollama" },
     { name = "openai" },
     { name = "pydantic" },
@@ -734,7 +879,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.46.0" },
+    { name = "fastmcp", specifier = ">=2.3.4" },
     { name = "ibm-watsonx-ai", specifier = ">=1.2.9" },
+    { name = "more-itertools", specifier = ">=10.7.0" },
     { name = "ollama", specifier = ">=0.4.7" },
     { name = "openai", specifier = ">=1.74.0" },
     { name = "pydantic", specifier = ">=2.6.0" },
@@ -769,6 +916,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/86/ec/535bf6f9bd280de6a4637526602a146a68fde757100ecf8c9333173392db/requests-2.32.2.tar.gz", hash = "sha256:dd951ff5ecf3e3b3aa26b40703ba77495dab41da839ae72ef3c8e5d8e2433289", size = 130327 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/20/748e38b466e0819491f0ce6e90ebe4184966ee304fe483e2c414b0f4ef07/requests-2.32.2-py3-none-any.whl", hash = "sha256:fc06670dd0ed212426dfeb94fc1b983d917c4f9847c863f313c9dfaaffb7c23c", size = 63902 },
+]
+
+[[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229 },
 ]
 
 [[package]]
@@ -819,6 +979,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -843,6 +1012,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "2.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/5f/28f45b1ff14bee871bacafd0a97213f7ec70e389939a80c60c0fb72a9fc9/sse_starlette-2.3.5.tar.gz", hash = "sha256:228357b6e42dcc73a427990e2b4a03c023e2495ecee82e14f07ba15077e334b2", size = 17511 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/48/3e49cf0f64961656402c0023edbc51844fe17afe53ab50e958a6dbbbd499/sse_starlette-2.3.5-py3-none-any.whl", hash = "sha256:251708539a335570f10eaaa21d1848a10c42ee6dc3a9cf37ef42266cdb1c52a8", size = 10233 },
+]
+
+[[package]]
+name = "starlette"
+version = "0.46.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037 },
 ]
 
 [[package]]
@@ -932,6 +1126,21 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/89/c527e6c848739be8ceb5c44eb8208c52ea3515c6cf6406aa61932887bf58/typer-0.15.4.tar.gz", hash = "sha256:89507b104f9b6a0730354f27c39fae5b63ccd0c95b1ce1f1a6ba0cfd329997c3", size = 101559 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/62/d4ba7afe2096d5659ec3db8b15d8665bdcb92a3c6ff0b95e99895b335a9c/typer-0.15.4-py3-none-any.whl", hash = "sha256:eb0651654dcdea706780c466cf06d8f174405a659ffff8f163cfbfee98c0e173", size = 45258 },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -971,6 +1180,19 @@ wheels = [
 ]
 
 [[package]]
+name = "uvicorn"
+version = "0.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/ae/9bbb19b9e1c450cf9ecaef06463e40234d98d95bf572fab11b4f19ae5ded/uvicorn-0.34.2.tar.gz", hash = "sha256:0e929828f6186353a80b58ea719861d2629d766293b6d19baf086ba31d4f3328", size = 76815 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/4b/4cef6ce21a2aaca9d852a6e84ef4f135d99fcd74fa75105e2fc0c8308acd/uvicorn-0.34.2-py3-none-any.whl", hash = "sha256:deb49af569084536d269fe0a6d67e3754f104cf03aba7c11c40f01aadf33c403", size = 62483 },
+]
+
+[[package]]
 name = "watchdog"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -992,4 +1214,35 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437 },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096 },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332 },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152 },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096 },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523 },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790 },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165 },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160 },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395 },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841 },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440 },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098 },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329 },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111 },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054 },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496 },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829 },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217 },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195 },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393 },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837 },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743 },
 ]


### PR DESCRIPTION
Issue: https://github.com/mikerhodes/rapport/issues/29

feat: support tool-calling via MCP

This commit adds support for calling tools provided by MCP servers.
The servers can either be reached over stdio, in which case Rapport
starts a child process and communicates over stdio, or HTTP, in which
case Rapport expects a server to be already running and exposing a
HTTP endpoint. The commit implements an allowlist approach for safety,
allowing only the tools in that list to be used by a model.

First, a user configures MCP servers by writing JSON into the config
screen set up by view_config.py. This is a bit fiddly but it'll do.
The pydantic errors are inscruitable but we don't leave the JSON
invalid. There is inline help, and an expander that will show active
tools for debugging.

Second, tools.py contains the code to create a ToolRegistry. This is
initialised with the configuration for MCP servers. It queries each
server for its available tools and compares them with the allowlist
configured for the server. Those tools on the list are added to the
registry.

The registry also provides for calling the tools found during
initialisation.

Tool calls are performed via the fastmcp library's client. This client
is async, so we do a basic wrapping of calls that use it via
asyncio.run(). This is a bit inefficient as, due to the library
design, we have to create a new connection each time. This isn't too bad
for the HTTP servers, but for stdio it means starting the server
each time we call a tool. Not great, but we can fix that later if
it's a problem.

Finally, we alter view_chat so that tool calls can be shown inline
with assistant chat messages, in a single chat block. This involves
creating tool request and response message types in chat model.
Rendering a chat is altered such that as we read the chat we are able
to place subsequent assistant or user messages in the same chat block.
We do this by creating a peekable iterator using more_itertools
package, which allows us to write methods that will consume all the
messages in each block while rendering them, and then when we peek
the iterator and find that it's flipped participant, we can return
and have the next item handled in the parent method.

Regenerating the assistant message doesn't quite work properly yet. It
doesn't reverse over all the assistants messages (which can now
include tool calls and responses). Overall things work okay though,
and we can fix it up later.

Example tool call with chat history tool call block expanded (the 
content is normally hidden):

<img width="1582" alt="Screenshot 2025-05-23 at 20 20 41" src="https://github.com/user-attachments/assets/b5ca4081-b278-444c-bde4-24f29ca35913" />

Configuration screen showing mildly annoying JSON editing:

<img width="1582" alt="Screenshot 2025-05-23 at 20 22 26" src="https://github.com/user-attachments/assets/c3e25c14-1fff-4236-a963-65c098e6b630" />
